### PR TITLE
page redirection for old shortname for workshop

### DIFF
--- a/workshops/GP/index.html
+++ b/workshops/GP/index.html
@@ -1,107 +1,15 @@
----
-title: Generalized Planning (GP) workshop at ICAPS-17
-layout: page
----
-<div class="container">
-  <div class="row">
-    <div class="3u 12u(mobile) important(mobile)">
-      <section>
-        <header>
-          <h3 class="top">Tentative Dates</h3>
-        </header>
-        <ul class="check-list">
-          <li><strong>March 15, 2017</strong> - Submissions Due</li>
-          <li><strong>April 10, 2017</strong> - Notification</li>
-          <li><strong>TBD, 2017</strong> - Camera-ready Due</li>
-          <li><strong>June 19-20, 2017</strong> - Workshop Date</li>
-        </ul> 
-      </section>
-      {% include workshops.html %}
-    </div>
-  <div class="9u 12u(mobile)">
-    <section>
-      <header>
-				<h1 class="top" id="generalized_planning_workshop_at_icaps_17">Generalized Planning workshop at ICAPS-17</h1>
-        
-        <p>
-        Pittsburgh, USA<br/>
-        19-20 June 2017
-        </p>
-      </header>
+<html>
+<html>
+  <meta http-equiv="refresh" content="0; url=http://homepages.inf.ed.ac.uk/vbelle/workshops/genplan17/">
+
+  <head>
+
+  </head>
+  <body>
+    <script language="javascript">
+      window.location.href = "http://homepages.inf.ed.ac.uk/vbelle/workshops/genplan17/"
+    </script>
 
 
-<h2 id="overview">Overview</h2>
-
-<p>Automated planning is a fundamental area of AI, concerned with computing behaviors which when executed in an initial state realize the goals and objectives of the agent. In the last 15 years, we have seen great advances in the efficiency of automated planning techniques, as a consequence of a variety of innovations, including advances in heuristic search for classical planning, and the application of classical planning to non-classical planning tasks. Nevertheless, industrial-level scalability remains a fundamental challenge to the broad applicability of AI automated planning techniques. This is especially notable when the space of objects is (possibly) infinite or when there is inherent uncertainty about the initial plan parameters.</p>
-
-<p>This workshop aims to bring together researchers working on emerging directions for addressing this challenge, including: (1) achieving scalability through plans that include cyclic flow of control and solve large classes of problems, (2) acquisition (through learning or search) of domain control knowledge for reducing the cost of planning, or otherwise structuring the space of solutions, (3) automated composition of pre-existing control modules like software services, and (4) synthesis of program-like structures from partial programs or goal-specifications. Common to all of these approaches is the notion of generalized plans, or plans that include rich control structures that resemble programs. In addition, all of these approaches share the fundamental problem of evaluating whether a given control structure will be helpful in developing a scalable solution for a given class of problem instances. While these approaches have achieved promising results, many fundamental challenges remain regarding the synthesis, analysis and composition of such generalized plans.</p>
-
-<p> See <a href="http://homepages.inf.ed.ac.uk/vbelle/workshops/gp17/">http://homepages.inf.ed.ac.uk/vbelle/workshops/gp17/</a> for the most up-to-date CFP.</p>
-
-<h2 id="call_for_papers">Call for papers</h2>
-
-<p>The focus of this workshop is on techniques for addressing these challenges in particular, and more generally on scalable representation and reasoning techniques for planning. An additional objective is to reevaluate some of the most fundamental, traditionally accepted notions in planning about plan structure and representation of domain knowledge. Some of the questions motivating this workshop are:</p>
-
-<ul>
-<li>How can we effectively find, represent and utilize high-level knowledge about planning domains?</li>
-<li>What separates planning problems from program synthesis?</li>
-<li>How can we effectively embed complex control structures in planning algorithms?</li>
-<li>What are the computational limits to the feasibility of these problems?</li>
-<li>Can restricted formulations of generalized planning that are practical and efficiently solvable be developed?</li>
-<li>How can abstraction techniques for understanding, analyzing and reasoning about programs be utilized for generalized planning?</li>
-</ul>
-
-<p>In addition to these key questions, we would like to additionally emphasize and encourage submissions on the following theme:</p>
-
-<ul>
-<li>How can we learn generalized plans and partial policies from data?</li>
-</ul>
-
-<p>We believe a deeper integration of machine learning approaches and planning algorithms presents an exciting and novel direction for formulating and solving generalized planning. Overall, potential topics include but are not limited to:</p>
-
-<ul>
-<li>generating plans with loops</li>
-<li>generating parameterized plans</li>
-<li>program synthesis</li>
-<li>instantiating parameterized plans</li>
-<li>planning with complex actions</li>
-<li>planning with plan scripts or schemas</li>
-<li>web service composition</li>
-<li>work-flows as plans</li>
-<li>learning and planning with domain control knowledge and/or complex actions (e.g., Golog, HTNs, control rules)</li>
-<li>planning with partial policies</li>
-<li>learning generalized plans and partial policies from data</li>
-</ul>
-
-<h2 id="important_dates">Important Dates</h2>
-
-<ul>
-<li>Submission deadline: March 15, 2016</li>
-<li>Notification date: April 10, 2016</li>
-<li>Workshop date: 19-20 of June, 2017 </li>
-</ul>
-
-<h2 id="submission_procedure">Submission Procedure</h2>
-
-<p>We welcome nove technical work, challenge papers, but also extended abstracts reporting research already published provided they align well with the workshop topic. <a href="http://www.aaai.org/Publications/Templates/AuthorKit17.zip">Papers are expected to use the AAAI style</a>. </p>
-
-<p>Three types of submissions are solicited:</p>
-
-<ul>
-<li>full-length papers (up to 6 pages + 1 page for references)</li>
-<li>challenge or position papers (2 pages + 1 page for references)</li>
-<li>already published papers (1 page extended abstract with a link to the full paper)</li>
-</ul>
-
-<p>Paper submissions should be made through the workshop EasyChair website, which will be made available shortly. </p>
-
-<h2 id="organizing_committee">Organizing Committee</h2>
-
-<p><strong>Siddharth Srivastava</strong>, United Technologies Research Center, siddharth.srivastava(at)utrc.utc.com <br />
-<strong>Sheila McIlraith</strong>, University of Toronto, sheila(at)cs.toronto.edu <br />
-<strong>Ron Petrick</strong>, Heriot-Watt University, r.petrick(at)hw.ac.uk <br />
-<strong>Vaishak Belle</strong>, University of Edinburgh, vaishak(at)ed.ac.uk</p>
-    </section>
-  </div>
-</div>
-
+  </body>
+</html>


### PR DESCRIPTION
Hi. As you know, we changed the short name of the website from GP to GenPlan. Currently 

http://icaps17.icaps-conference.org/workshops/GP/

is still active, and I just created a redirection page to our website 

http://homepages.inf.ed.ac.uk/vbelle/workshops/genplan17/

